### PR TITLE
Define widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@
 > [!TIP]
 > If in KaeruMixin you have use `watch$` with `watch` and `watchEffect$` with `watchEffect`
 
+## List composables
+- `useContext`
+- `useHoverWidget`
+- `useRef`
+- `useState`
+- `useWidgetBounding`
+- `useWidgetSize`
+
 ---
 
 ## 📦 Installation

--- a/README.md
+++ b/README.md
@@ -36,6 +36,59 @@ import 'package:kaeru/kaeru.dart';
 
 ## 🏗 API Documentation
 
+### **Widget: `defineWidget`**
+View example. All `life` and `reactivity` ready with name `$ + <name>` (e.g: `$ref`, `$computed`, `$watch`, `$onBeforeUnmount`...)
+
+#### Example
+```dart
+typedef FooProps = ({Ref<int> counter});
+// ignore: non_constant_identifier_names
+final Foo = defineWidget((FooProps props) {
+  final foo = $ref(0);
+
+  void onPressed() {
+    foo.value++;
+  }
+
+  void resetParent() {
+    props.counter.value = 0;
+  }
+
+  return (ctx) => Row(
+        children: [
+          TextButton(
+              onPressed: onPressed,
+              child:
+                  Text('counter + foo = ${props.counter.value + foo.value}')),
+          TextButton(
+              onPressed: resetParent, child: Text('Reset counter parent'))
+        ],
+      );
+});
+
+typedef CounterProps = ({VoidCallback onMax});
+// ignore: non_constant_identifier_names
+final Counter = defineWidget((CounterProps props) {
+  final counter = $ref(0);
+
+  print('Render once');
+
+  void onPressed() {
+    counter.value++;
+
+    if (counter.value > 10) props.onMax();
+  }
+
+  return (ctx) => Row(
+        children: [
+          TextButton(
+              onPressed: onPressed, child: Text('counter = $counter.value')),
+          Foo((counter: counter))
+        ],
+      );
+});
+```
+
 ### 1️⃣ **Reactive State: `Ref<T>`**
 
 Represents a reactive variable that automatically triggers updates when changed.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -230,6 +230,7 @@ final Foo = defineWidget((FooProps props) {
 typedef CounterProps = ({VoidCallback onMax});
 final counterDefine = defineWidget((CounterProps props) {
   final counter = $ref(0);
+  final (isHover: isHover, hoverWrap: hoverWrap) = useHoverWidget();
 
   print('Render once');
 
@@ -243,7 +244,9 @@ final counterDefine = defineWidget((CounterProps props) {
         children: [
           TextButton(
               onPressed: onPressed, child: Text('counter = $counter.value')),
-          Foo((counter: counter))
+          Text('Foo is hoving: ${isHover.value}',
+              style: TextStyle(color: Colors.red)),
+          hoverWrap((_) => Foo((counter: counter)))
         ],
       );
 });

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -19,7 +19,12 @@ class _MyAppState extends State<MyApp> {
         home: Scaffold(
             appBar: AppBar(title: const Text("Kaeru Example")),
             body: Padding(
-                padding: const EdgeInsets.all(16.0), child: TestUsePick())));
+                padding: const EdgeInsets.all(16.0),
+                child: Column(children: [
+                  TextButton(
+                      child: Text('refresh'), onPressed: () => setState(() {})),
+                  counterDefine((onMax: () => print('OK'))),
+                ]))));
   }
 }
 
@@ -194,3 +199,51 @@ class _TestUsePickState extends State<TestUsePick> with KaeruMixin {
     );
   }
 }
+
+//============================= test define_widget //
+
+typedef FooProps = ({Ref<int> counter});
+// ignore: non_constant_identifier_names
+final Foo = defineWidget((FooProps props) {
+  final foo = $ref(0);
+
+  void onPressed() {
+    foo.value++;
+  }
+
+  void resetParent() {
+    props.counter.value = 0;
+  }
+
+  return (ctx) => Row(
+        children: [
+          TextButton(
+              onPressed: onPressed,
+              child:
+                  Text('counter + foo = ${props.counter.value + foo.value}')),
+          TextButton(
+              onPressed: resetParent, child: Text('Reset counter parent'))
+        ],
+      );
+});
+
+typedef CounterProps = ({VoidCallback onMax});
+final counterDefine = defineWidget((CounterProps props) {
+  final counter = $ref(0);
+
+  print('Render once');
+
+  void onPressed() {
+    counter.value++;
+
+    if (counter.value > 10) props.onMax();
+  }
+
+  return (ctx) => Row(
+        children: [
+          TextButton(
+              onPressed: onPressed, child: Text('counter = $counter.value')),
+          Foo((counter: counter))
+        ],
+      );
+});

--- a/lib/composables/define_widget/auto_dispose.dart
+++ b/lib/composables/define_widget/auto_dispose.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+import 'bus.dart';
+
+T autoContextDispose<T extends ChangeNotifier>(T notifier) {
+  final ctx = getCurrentState();
+  if (ctx == null) throw Exception('Current context is null');
+
+  ctx.notifiersStore.add(notifier);
+  return notifier;
+}
+
+VoidCallback autoContextDisposeFn(VoidCallback fn) {
+  final ctx = getCurrentState();
+  if (ctx == null) throw Exception('Current context is null');
+
+  ctx.disposesStore.add(fn);
+  return fn;
+}

--- a/lib/composables/define_widget/auto_dispose.dart
+++ b/lib/composables/define_widget/auto_dispose.dart
@@ -1,19 +1,13 @@
 import 'package:flutter/material.dart';
 
-import 'bus.dart';
+import 'composables/use_state.dart';
 
 T autoContextDispose<T extends ChangeNotifier>(T notifier) {
-  final ctx = getCurrentState();
-  if (ctx == null) throw Exception('Current context is null');
-
-  ctx.notifiersStore.add(notifier);
+  useState().notifiersStore.add(notifier);
   return notifier;
 }
 
 VoidCallback autoContextDisposeFn(VoidCallback fn) {
-  final ctx = getCurrentState();
-  if (ctx == null) throw Exception('Current context is null');
-
-  ctx.disposesStore.add(fn);
+  useState().disposesStore.add(fn);
   return fn;
 }

--- a/lib/composables/define_widget/bus.dart
+++ b/lib/composables/define_widget/bus.dart
@@ -1,0 +1,12 @@
+import 'widget/define_widget_builder.dart';
+
+DefineWidgetBuilderState? _currentState;
+DefineWidgetBuilderState? setCurrentState(DefineWidgetBuilderState state) {
+  final old = _currentState;
+  _currentState = state;
+  return old;
+}
+
+DefineWidgetBuilderState? getCurrentState() => _currentState;
+void restoreCurrentState(DefineWidgetBuilderState? state) =>
+    _currentState = state;

--- a/lib/composables/define_widget/composables/use_context.dart
+++ b/lib/composables/define_widget/composables/use_context.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+import 'use_state.dart';
+
+BuildContext useContext() {
+  return useState().context;
+}

--- a/lib/composables/define_widget/composables/use_hover_widget.dart
+++ b/lib/composables/define_widget/composables/use_hover_widget.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
+import 'package:kaeru/kaeru.dart';
+
+enum HoverMode { mouse, touch, both, atomic }
+
+typedef UseHoverWidgetReturn = ({
+  Ref<bool> isHover,
+  Widget Function(WidgetBuilder builder) hoverWrap,
+});
+
+UseHoverWidgetReturn useHoverWidget({HoverMode mode = HoverMode.atomic}) {
+  final isHover = $ref(false);
+  final key = GlobalKey();
+
+  void setHover(bool value) {
+    isHover.value = value;
+  }
+
+  // Determine effective mode
+  HoverMode effectiveMode = mode;
+  if (mode == HoverMode.atomic) {
+    if (defaultTargetPlatform == TargetPlatform.android ||
+        defaultTargetPlatform == TargetPlatform.iOS) {
+      effectiveMode = HoverMode.touch;
+    } else {
+      effectiveMode = HoverMode.mouse;
+    }
+  }
+
+  Widget hoverWrap(WidgetBuilder builder) {
+    Widget child = Builder(builder: builder);
+
+    if (effectiveMode == HoverMode.mouse || effectiveMode == HoverMode.both) {
+      child = MouseRegion(
+        onEnter: (_) => setHover(true),
+        onExit: (_) => setHover(false),
+        child: child,
+      );
+    }
+
+    if (effectiveMode == HoverMode.touch || effectiveMode == HoverMode.both) {
+      child = Listener(
+        key: key,
+        onPointerDown: (_) => setHover(true),
+        onPointerUp: (_) => setHover(false),
+        onPointerCancel: (_) => setHover(false),
+        behavior: HitTestBehavior.translucent,
+        child: child,
+      );
+    }
+
+    return child;
+  }
+
+  return (
+    isHover: isHover,
+    hoverWrap: hoverWrap,
+  );
+}

--- a/lib/composables/define_widget/composables/use_ref.dart
+++ b/lib/composables/define_widget/composables/use_ref.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/widgets.dart';
+
+GlobalKey useRef() {
+  final key = GlobalKey();
+
+  return key;
+}

--- a/lib/composables/define_widget/composables/use_state.dart
+++ b/lib/composables/define_widget/composables/use_state.dart
@@ -1,0 +1,8 @@
+import '../bus.dart';
+import '../widget/define_widget_builder.dart';
+
+DefineWidgetBuilderState useState() {
+  final ctx = getCurrentState();
+  if (ctx == null) throw Exception('Current context is null');
+  return ctx;
+}

--- a/lib/composables/define_widget/composables/use_widget_bounding.dart
+++ b/lib/composables/define_widget/composables/use_widget_bounding.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/widgets.dart';
+import 'package:kaeru/kaeru.dart';
+
+class WidgetBounding {
+  final double x;
+  final double y;
+  final double width;
+  final double height;
+
+  const WidgetBounding({
+    required this.x,
+    required this.y,
+    required this.width,
+    required this.height,
+  });
+
+  double get top => y;
+  double get left => x;
+  double get right => x + width;
+  double get bottom => y + height;
+}
+
+typedef UseWidgetBoundingReturn = ({
+  GlobalKey key,
+  Computed<double?> x,
+  Computed<double?> y,
+  Computed<double?> top,
+  Computed<double?> left,
+  Computed<double?> right,
+  Computed<double?> bottom,
+  Computed<double?> width,
+  Computed<double?> height,
+});
+
+UseWidgetBoundingReturn useWidgetBounding() {
+  final key = GlobalKey();
+  final bounding = $ref<WidgetBounding?>(null);
+
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    final context = key.currentContext;
+    if (context == null) return;
+    final renderBox = context.findRenderObject() as RenderBox?;
+    if (renderBox == null || !renderBox.hasSize) return;
+
+    final size = renderBox.size;
+    final offset = renderBox.localToGlobal(Offset.zero);
+
+    bounding.value = WidgetBounding(
+      x: offset.dx,
+      y: offset.dy,
+      width: size.width,
+      height: size.height,
+    );
+  });
+
+  return (
+    key: key,
+    x: $computed(() => bounding.value?.x),
+    y: $computed(() => bounding.value?.y),
+    top: $computed(() => bounding.value?.top),
+    left: $computed(() => bounding.value?.left),
+    right: $computed(() => bounding.value?.right),
+    bottom: $computed(() => bounding.value?.bottom),
+    width: $computed(() => bounding.value?.width),
+    height: $computed(() => bounding.value?.height),
+  );
+}

--- a/lib/composables/define_widget/composables/use_widget_size.dart
+++ b/lib/composables/define_widget/composables/use_widget_size.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/widgets.dart';
+import 'package:kaeru/kaeru.dart';
+
+typedef UseWidgetSizeReturn = ({
+  GlobalKey key,
+  Ref<double?> width,
+  Ref<double?> height
+});
+
+UseWidgetSizeReturn useWidgetSize(GlobalKey key) {
+  final width = $ref<double?>(null);
+  final height = $ref<double?>(null);
+
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    final context = key.currentContext;
+    if (context != null) {
+      final renderBox = context.findRenderObject() as RenderBox?;
+      if (renderBox != null && renderBox.hasSize) {
+        width.value = renderBox.size.width;
+        height.value = renderBox.size.height;
+      }
+    }
+  });
+
+  return (key: key, width: width, height: height);
+}

--- a/lib/composables/define_widget/define_widget.dart
+++ b/lib/composables/define_widget/define_widget.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:kaeru/kaeru.dart';
+
+import 'widget/define_widget_builder.dart';
+
+// typedef WidgetBuilderWithArgs<T> = Widget Function(T args);
+
+Widget Function(T args) defineWidget<T>(FunctionRender Function(T args) builder,
+    {List<dynamic>? dependencies}) {
+  return (args, {Key? key}) {
+    return DefineWidgetBuilder(
+      key: key,
+      dependencies: dependencies,
+      initState: (state) {
+        final old = setCurrentState(state);
+
+        final render = builder(args);
+
+        restoreCurrentState(old);
+
+        return render;
+      },
+      build: (context, render) {
+        return Watch(dependencies: dependencies, () => render(context));
+      },
+    );
+  };
+}

--- a/lib/composables/define_widget/life.dart
+++ b/lib/composables/define_widget/life.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/widgets.dart';
+import 'package:kaeru/kaeru.dart';
+
+KaeruLifeMixin _getLife() {
+  final ctx = getCurrentState();
+  if (ctx == null) throw Exception('Current context is null');
+
+  return ctx;
+}
+
+void $onMounted(VoidCallback callback) {
+  _getLife().onMounted(callback);
+}
+
+void $onDependenciesChanged(VoidCallback callback) {
+  _getLife().onDependenciesChanged(callback);
+}
+
+void $onUpdated(VoidCallback callback) {
+  _getLife().onUpdated(callback);
+}
+
+void $onBeforeUnmount(VoidCallback callback) {
+  _getLife().onBeforeUnmount(callback);
+}
+
+void $onDeactivated(VoidCallback callback) {
+  _getLife().onDeactivated(callback);
+}

--- a/lib/composables/define_widget/life.dart
+++ b/lib/composables/define_widget/life.dart
@@ -1,29 +1,23 @@
 import 'package:flutter/widgets.dart';
-import 'package:kaeru/kaeru.dart';
 
-KaeruLifeMixin _getLife() {
-  final ctx = getCurrentState();
-  if (ctx == null) throw Exception('Current context is null');
-
-  return ctx;
-}
+import 'composables/use_state.dart';
 
 void $onMounted(VoidCallback callback) {
-  _getLife().onMounted(callback);
+  useState().onMounted(callback);
 }
 
 void $onDependenciesChanged(VoidCallback callback) {
-  _getLife().onDependenciesChanged(callback);
+  useState().onDependenciesChanged(callback);
 }
 
 void $onUpdated(VoidCallback callback) {
-  _getLife().onUpdated(callback);
+  useState().onUpdated(callback);
 }
 
 void $onBeforeUnmount(VoidCallback callback) {
-  _getLife().onBeforeUnmount(callback);
+  useState().onBeforeUnmount(callback);
 }
 
 void $onDeactivated(VoidCallback callback) {
-  _getLife().onDeactivated(callback);
+  useState().onDeactivated(callback);
 }

--- a/lib/composables/define_widget/main.dart
+++ b/lib/composables/define_widget/main.dart
@@ -1,4 +1,8 @@
 export 'composables/use_context.dart';
+export 'composables/use_hover_widget.dart';
+export 'composables/use_ref.dart';
+export 'composables/use_widget_bounding.dart';
+export 'composables/use_widget_size.dart';
 export 'composables/use_state.dart';
 export 'auto_dispose.dart';
 export 'bus.dart';

--- a/lib/composables/define_widget/main.dart
+++ b/lib/composables/define_widget/main.dart
@@ -1,0 +1,5 @@
+export 'auto_dispose.dart';
+export 'bus.dart';
+export 'define_widget.dart';
+export 'life.dart';
+export 'reactivity.dart';

--- a/lib/composables/define_widget/main.dart
+++ b/lib/composables/define_widget/main.dart
@@ -1,3 +1,5 @@
+export 'composables/use_context.dart';
+export 'composables/use_state.dart';
 export 'auto_dispose.dart';
 export 'bus.dart';
 export 'define_widget.dart';

--- a/lib/composables/define_widget/reactivity.dart
+++ b/lib/composables/define_widget/reactivity.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/foundation.dart';
+import 'package:kaeru/composables/watch.dart';
+import 'package:kaeru/composables/watch_effect.dart';
+import 'package:kaeru/foundation/async_computed.dart';
+import 'package:kaeru/foundation/computed.dart';
+import 'package:kaeru/foundation/ref.dart';
+
+import 'auto_dispose.dart';
+
+/// Creates a reactive [Ref] with the given initial [value]. This can be
+/// used to store and notify changes to a mutable value over the lifetime
+/// of the widget.
+///
+/// The [Ref] instance is automatically disposed when the widget is disposed.
+///
+/// Example:
+///
+/// ```dart
+/// final count = ref(0);
+///
+/// void increment() {
+///   count.value++;
+/// }
+/// ```
+///
+/// See also:
+///
+///  * [Ref], which is a reactive reference that notifies listeners of changes.
+///  * [Computed], which is a lazy-evaluated value that automatically updates
+///    whenever its dependencies change.
+///  * [AsyncComputed], which is a lazy-evaluated value that automatically updates
+///    whenever its dependencies change, and can be used with async functions.
+///  * [watch], which allows you to listen to changes to a list of values.
+///  * [watchEffect], which allows you to listen to changes to a function.
+Ref<U> $ref<U>(U value) => autoContextDispose(Ref(value));
+
+/// Creates a reactive [Computed] with the provided [getter] function.
+/// The value is recomputed only when dependencies change and is guaranteed
+/// to notify listeners when it is updated.
+///
+/// The [Computed] instance is automatically disposed when the widget is disposed.
+Computed<U> $computed<U>(U Function() getter) =>
+    autoContextDispose(Computed(getter));
+
+/// Creates an instance of [AsyncComputed] with the given async function.
+///
+/// - [_getValue]: The function that fetches the computed value asynchronously.
+/// - [defaultValue]: A default value before the async computation completes.
+/// - [beforeUpdate]: A function to set a temporary value before computation.
+/// - [notifyBeforeUpdate]: If true, notifies listeners when [beforeUpdate] sets a new value.
+/// - [onError]: Callback function for handling errors during async computation.
+/// - [immediate]: If true, starts the async computation immediately upon creation.
+///
+/// The [AsyncComputed] instance is automatically disposed when the widget is disposed.
+AsyncComputed<U> $asyncComputed<U>(final Future<U> Function() getValue,
+        {U? defaultValue,
+        U? Function()? beforeUpdate,
+        bool notifyBeforeUpdate = true,
+        void Function(dynamic error)? onError,
+        immediate = false}) =>
+    autoContextDispose(AsyncComputed<U>(getValue,
+        defaultValue: defaultValue,
+        beforeUpdate: beforeUpdate,
+        notifyBeforeUpdate: notifyBeforeUpdate,
+        onError: onError,
+        immediate: immediate));
+
+/// Sets up a reactive effect triggered by [callback] and returns a function
+/// to dispose of the effect when it’s no longer needed.
+///
+/// The [watchEffect] instance is automatically disposed when the widget is disposed.
+VoidCallback $watchEffect(VoidCallback callback) =>
+    autoContextDisposeFn(watchEffect$(callback));
+
+/// Sets up a watcher on the given [source] and triggers the [callback] when any
+/// of the [Listenable] objects in the source change. If [immediate] is true,
+/// the [callback] is triggered immediately after setting up the listener.
+///
+/// Returns a [VoidCallback] that can be used to remove the listener when it's
+/// no longer needed.
+///
+/// The [watch] instance is automatically disposed when the widget is disposed.
+VoidCallback $watch(Iterable<Listenable?> source, VoidCallback callback,
+        {bool immediate = false}) =>
+    autoContextDisposeFn(watch$(source, callback, immediate: immediate));

--- a/lib/composables/define_widget/widget/define_widget_builder.dart
+++ b/lib/composables/define_widget/widget/define_widget_builder.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:kaeru/kaeru.dart';
+
+typedef FunctionRender = Widget Function(BuildContext context);
+
+class DefineWidgetBuilder extends StatefulWidget {
+  final FunctionRender Function(DefineWidgetBuilderState state) initState;
+  final List<dynamic>? dependencies;
+  final Widget Function(BuildContext context, FunctionRender render) build;
+
+  const DefineWidgetBuilder(
+      {required super.key,
+      required this.initState,
+      required this.dependencies,
+      required this.build});
+
+  @override
+  createState() => DefineWidgetBuilderState();
+}
+
+class DefineWidgetBuilderState extends State<DefineWidgetBuilder>
+    with KaeruLifeMixin {
+  late final notifiersStore = <ChangeNotifier>{};
+  late final disposesStore = <VoidCallback>{};
+
+  late final FunctionRender _render;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _render = widget.initState(this);
+  }
+
+  @override
+  Widget build(context) => widget.build(context, _render);
+
+  @override
+  void dispose() {
+    for (var notifier in notifiersStore) {
+      notifier.dispose();
+    }
+    for (var fn in disposesStore) {
+      fn();
+    }
+
+    super.dispose();
+
+    if (getCurrentState() == this) restoreCurrentState(null);
+  }
+}

--- a/lib/composables/define_widget/widget/define_widget_builder.dart
+++ b/lib/composables/define_widget/widget/define_widget_builder.dart
@@ -41,12 +41,15 @@ class DefineWidgetBuilderState extends State<DefineWidgetBuilder>
     for (var notifier in notifiersStore) {
       notifier.dispose();
     }
+    notifiersStore.clear();
+  
     for (var fn in disposesStore) {
       fn();
     }
-
-    super.dispose();
+    disposesStore.clear();
 
     if (getCurrentState() == this) restoreCurrentState(null);
+  
+    super.dispose();
   }
 }

--- a/lib/composables/next_tick.dart
+++ b/lib/composables/next_tick.dart
@@ -3,6 +3,5 @@ import 'package:flutter/foundation.dart';
 Future<void> nextTick([VoidCallback? callback]) async {
   await Future.delayed(Duration.zero);
 
-      await Future.delayed(Duration.zero);
   callback?.call();
 }

--- a/lib/kaeru.dart
+++ b/lib/kaeru.dart
@@ -1,3 +1,4 @@
+export 'composables/define_widget/main.dart';
 export 'composables/exception/no_watcher_found_exception.dart';
 export 'composables/next_tick.dart';
 export 'composables/on_watcher_cleanup.dart';


### PR DESCRIPTION
### **PR Type**
enhancement, documentation, tests


___

### **Description**
- Introduce `defineWidget` API for composable widgets
  - Adds core builder, lifecycle, and reactivity utilities
  - Provides auto-disposal and context/state management
  - Includes composables: hover detection, widget bounding/size, refs

- Add comprehensive reactivity helpers with `$ref`, `$computed`, `$watch`, etc.

- Expand documentation with usage examples and composables list

- Update example app to demonstrate new `defineWidget` usage


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>main.dart</strong><dd><code>Demonstrate defineWidget and composables in example app</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-72fd825ad17ce7800a2078e06f0dff1e12836ee59760465e78d9a5d222cebd15">+57/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>14 files</summary><table>
<tr>
  <td><strong>auto_dispose.dart</strong><dd><code>Add auto-dispose helpers for notifiers and callbacks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-796a4837cb16ca79d8e57ea59674521304f61d1ef7e1d090c15377aa8b03e71f">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>bus.dart</strong><dd><code>Add internal state bus for widget context management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-4872ef9d5603e626978703a37cc4d56a108ead0e218e7015b2da5e20dde39e88">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use_context.dart</strong><dd><code>Add useContext composable for accessing BuildContext</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-96a33aff320719826f843477f19a061ecda061dd6506ae8cb31c406b64354815">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use_hover_widget.dart</strong><dd><code>Add useHoverWidget for hover/touch detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-dcba2d19828fec00fafe7cd7f62a796a61a511c8fdce39be97209d4848a46868">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use_ref.dart</strong><dd><code>Add useRef composable for GlobalKey management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-2492b72495ed0b4f6b97a5d05d5c7eec8d951fb2c88bb182e51e92205d4a40ed">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use_state.dart</strong><dd><code>Add useState composable for accessing widget state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-0d821e99757cc00b071ecd9552f0fa4f8e0d4b67430dc8f51f89cce0de408db7">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use_widget_bounding.dart</strong><dd><code>Add useWidgetBounding for widget position/size tracking</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-02ea01bb885bb76f2f50cabf73ae130c0c42b8cc714a7d556b5606caa2769f85">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>use_widget_size.dart</strong><dd><code>Add useWidgetSize for widget dimension tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-aa086b984c12c55eca21463b64d4f9345293c2e2e009a02c613e3fd2c7e8e45d">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>define_widget.dart</strong><dd><code>Implement defineWidget builder for composable widgets</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-8f349d8070b2ce83d81e4184cfcd4ee35a4b0bda33ed65d14ca4e645bdd696c2">+28/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>life.dart</strong><dd><code>Add lifecycle hooks for composable widgets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-82341b647b10e1f8f177ca8556931f0f09f8a16bd437e6af43cd4fe95b8f50bf">+23/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.dart</strong><dd><code>Export defineWidget composables and utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-dba3bd0bdc50870211baa3479d7ef1b97c56042f12eed4644a3407f30095e3dc">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>reactivity.dart</strong><dd><code>Add reactivity helpers: $ref, $computed, $watch, etc.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-3c793849bbb7677be68d8e9f673a4b5f98255467b37ae1d13e1c16fbbca13f33">+85/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>define_widget_builder.dart</strong><dd><code>Core DefineWidgetBuilder widget and state implementation</code>&nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-8926c6702a7940dee89968e99c172d81471da4026480fb163a6081764fd81bad">+52/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>kaeru.dart</strong><dd><code>Export defineWidget module in main library entrypoint</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-bfd9c54d006d87ca094af7b9f7a6d09bf7d7ab68c1de909f4410d9b98b479746">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>next_tick.dart</strong><dd><code>Minor formatting cleanup in nextTick</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-0b3fe42fedbab8e4ea6a490d9d82e275866d963bdcd00ce98ae66259f8aaa525">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Document defineWidget API, composables, and usage examples</code></dd></td>
  <td><a href="https://github.com/tachibana-shin/flutter_kaeru/pull/3/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a suite of composable utilities for Flutter, including context access, hover detection, reference management, widget bounding and sizing, and reactive state management.
  - Added new widget lifecycle hooks and automatic disposal management for cleaner resource handling.
  - Enabled creation of reactive widgets with new composable patterns and lifecycle integrations.
  - Enhanced main app UI with interactive widgets demonstrating reactive state, hover detection, and parent-child state manipulation.

- **Documentation**
  - Updated README with a detailed section on available composables and API documentation, including examples for widget creation and reactivity.

- **Refactor**
  - Centralized exports for easier access to composable utilities throughout the codebase.

- **Style**
  - Minor simplification of asynchronous utility for improved efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->